### PR TITLE
Change WP link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,7 @@
             </h1>
 
             <div class="col-10 mx-auto d-block d-lg-flex align-items-center justify-content-center mb-5">
-              <a href="https://docs.mmx.network/MMX_Whitepaper_290125.pdf" target="_blank"
+              <a href="https://docs.mmx.network/articles/general/mmx-whitepaper/" target="_blank"
                 class="btn btn-lg btn-primary btn-custom d-flex align-items-center justify-content-center mx-3 my-3 wp">Read
                 Whitepaper</a>
               <a href="https://github.com/madMAx43v3r/mmx-node/releases" target="_blank"


### PR DESCRIPTION
PR for changed Whitepaper link (suggestion)

Changes:
- Change Whitepaper button link to article, vs. direct PDF
  - Make people only taking a quick look at Whitepaper indirectly see that MMX is fully documented (mmx-docs site).
